### PR TITLE
Create missing-csrf.rb

### DIFF
--- a/missing-csrf.rb
+++ b/missing-csrf.rb
@@ -1,0 +1,24 @@
+# ruleid:missing-csrf-protection
+class DangerousController < ActionController::Base
+
+  puts "do more stuff"
+
+end
+
+# ok:missing-csrf-protection
+class OkController < ActionController::Base
+
+  protect_from_forgery :with => :exception
+
+  puts "do more stuff"
+
+end
+
+# ok:missing-csrf-protection
+class OkController < ActionController::Base
+
+  protect_from_forgery prepend: true, with: :exception
+
+  puts "do more stuff"
+
+end


### PR DESCRIPTION
This vulnerable code is from the [Semgrep registry](https://semgrep.dev/playground/r/ruby.lang.security.missing-csrf-protection.missing-csrf-protection?editorMode=advanced).